### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Using serverless
 ```bash
-$ serverless install --url https://github.com/mrdck/serverless-typescript-template --name serverless-application
+serverless install --url https://github.com/mrdck/serverless-typescript-template --name serverless-application
 ```
 
 Using git clone


### PR DESCRIPTION
When I try to use copied an installation command, I always should remove the `$` character from the beginning of the command. 